### PR TITLE
ignoreIncomingPath issue fixed

### DIFF
--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -14,7 +14,7 @@ function _getSampler() {
   function _ignoreSpecifiedPaths(spanName, spanKind, attributes) {
     if (!cds.env.requires.telemetry.instrumentations?.http) return false
 
-    const { ignoreIncomingPaths } = cds.env.requires.telemetry.instrumentations.http
+    const { ignoreIncomingPaths } = cds.env.requires.telemetry.instrumentations.http.config
     return (
       !Array.isArray(ignoreIncomingPaths) ||
       (Array.isArray(ignoreIncomingPaths) && !ignoreIncomingPaths.some(path => path === spanName)


### PR DESCRIPTION
ignoreIncomingPath was not working because we were trying to check cds.env.requires.telemetry.instrumentations.http however in our package.json configuration it is : "cds": { "telemetry":{
 "instrumentations": {
            "http": {
              "module": "@opentelemetry/instrumentation-http",
              "class": "HttpInstrumentation",
              "config":{
                   "ignoreIncomingPaths": [
                    "/dbHealth/*",
                    "/metrics"
              ]
             }
            }
          }}}

So config field is missing .